### PR TITLE
round up amounts of the transactions

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -9,7 +9,7 @@ const { amountToInteger } = actual.utils;
 function amountFromYnab(amount) {
   // ynabs multiplies amount by 1000 and actual by 100
   // so, this function divides by 10
-  return amount/10;
+  return Math.round(amount/10);
 }
 
 function monthFromDate(date) {


### PR DESCRIPTION
In some cases (mostly when the YNAB API was used to create the transaction),
there may be transactions with amounts that are not integers. For example, in
recent import I had a transaction with amount set to `-4059`. That transaction
is displayed correctly in YNAB as `4.06 GBP`, but trips up the import here.

See https://github.com/actualbudget/import-ynab5/issues/8 for more examples.