### PR TITLE
Fix importer: weird amounts in YNAB

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -9,7 +9,7 @@ const { amountToInteger } = actual.utils;
 function amountFromYnab(amount) {
   // ynabs multiplies amount by 1000 and actual by 100
   // so, this function divides by 10
-  return amount/10;
+  return Math.ceil(amount/10);
 }
 
 function monthFromDate(date) {


### PR DESCRIPTION
YNAB is a bit weird.. in their WEB UI they show a correct amount, but the API export is a bit messed up. Here's an example:

```
{
    "id": "xxxxx",
    "date": "2021-11-11",
    "amount": -3673807,
    "memo": "Automatic investment account update",
    "cleared": "uncleared",
    "approved": true,
    "flag_color": null,
    "account_id": "xxxx",
    "payee_id": null,
    "category_id": null,
    "transfer_account_id": null,
    "transfer_transaction_id": null,
    "matched_transaction_id": null,
    "import_id": null,
    "deleted": false
}
```

In WEB UI it appears as `3,673.81`

---

Error without the fix:

```
Importing Accounts...
Importing Categories...
Importing Payees...
Importing Transactions...
Error: [API Error] Can't convert to integer: -367380.7
    at /Users/matiss/repos/actual/import-ynab5/node_modules/@actual-app/api/connection.js:26:13
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async /Users/matiss/repos/actual/import-ynab5/importer.js:242:7
    at async Promise.all (index 1)
    at async importTransactions (/Users/matiss/repos/actual/import-ynab5/importer.js:186:3)
    at async doImport (/Users/matiss/repos/actual/import-ynab5/importer.js:306:3)
    at async /Users/matiss/repos/actual/import-ynab5/node_modules/@actual-app/api/connection.js:113:5
    at async _run (/Users/matiss/repos/actual/import-ynab5/node_modules/@actual-app/api/connection.js:91:11)
    at async run (/Users/matiss/repos/actual/import-ynab5/index.js:6:3)
```