### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ npx @actual-app/import-ynab5 <path-to-ynab5-file>
 
 Read below for how to get your YNAB5 file.
 
-Almost everything should be working now. Subtransactions and imported bank transactions id are still in the works.
+Almost everything should be working now. Imported bank transaction ids are still in the works.
 
 ## TODO
  - There might be a way to set carryover using internal categories from YNAB (Deferred Income Subcategory and Immediate Income Subcategory)
  - Docs of how credit cards translate from Actual to YNAB
  - Maybe something else I'm missing
  - Remove ynab transfer payees not used by actual
- - Solve subtransactions and imported bank transactions id
+ - Import bank transaction ids
 
 ## How to use the importer
 


### PR DESCRIPTION
Subtransactions (aka splits, right?) seem to import fine in the importer's current state. 
<img width="878" alt="split" src="https://user-images.githubusercontent.com/5862724/142300977-25acedbf-7f94-4ab8-9f70-8a3f062ab62c.png">

I'm assuming https://github.com/actualbudget/import-ynab5/commit/52b03866f2e60634a98dc5dcfd49ea678cb68f10 did the trick.
Suspect that note can be dropped.