### PR TITLE
Set imported transaction IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ npx @actual-app/import-ynab5 <path-to-ynab5-file>
 
 Read below for how to get your YNAB5 file.
 
-Almost everything should be working now. Imported bank transaction ids are still in the works.
+Almost everything should be working now.
 
 ## TODO
  - There might be a way to set carryover using internal categories from YNAB (Deferred Income Subcategory and Immediate Income Subcategory)
  - Docs of how credit cards translate from Actual to YNAB
  - Maybe something else I'm missing
  - Remove ynab transfer payees not used by actual
- - Import bank transaction ids
 
 ## How to use the importer
 

--- a/importer.js
+++ b/importer.js
@@ -213,7 +213,7 @@ async function importTransactions(data, entityIdMap) {
             category: entityIdMap.get(transaction.category_id) || null,
             cleared: ["cleared", "reconciled"].includes(transaction.cleared),
             notes: transaction.memo || null,
-            //imported_id,
+            imported_id: transaction.import_id || null,
             transfer_id: entityIdMap.get(transaction.transfer_transaction_id) || null,
             subtransactions: subtransactions,
           };


### PR DESCRIPTION
Answering my own question from #12.
> Can anyone confirm or deny that YNAB import_id could be safely mapped to Actual imported_id?

I believe that mapping is safe. I've implemented it in this tiny PR.

From [YNAB's API docs](https://api.youneedabudget.com/v1#):

> import_id
If the Transaction was imported, this field is a unique (by account) import identifier. If this transaction was imported through File Based Import or Direct Import and not through the API, the import_id will have the format: 'YNAB:[milliunit_amount]:[iso_date]:[occurrence]'. For example, a transaction dated 2015-12-30 in the amount of -$294.23 USD would have an import_id of 'YNAB:-294230:2015-12-30:1’. If a second transaction on the same account was imported and had the same date and same amount, its import_id would be 'YNAB:-294230:2015-12-30:2’.

So whether your transactions were imported via file, YNAB auto-import, or via API some other way, `import_id` is the only property a YNAB transaction has for holding a unique ID generated by YNAB or the bank.
