### PR TITLE
Handle JSON data with and without a nested "data" attribute (fixes #9)

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -330,8 +330,12 @@ async function importYNAB5(filepath) {
     throw new Error('Error parsing file');
   }
 
-  return actual.runImport(data.data.budget.name, () =>
-    doImport(data.data.budget)
+  if(data.data) {
+    data = data.data;
+  }
+
+  return actual.runImport(data.budget.name, () =>
+    doImport(data.budget)
   );
 }
 


### PR DESCRIPTION
Looks like some data in the JSON file is nested under `data` and others not. No idea way, maybe different versions of the YNAB API.